### PR TITLE
enable CSRF on unlock form

### DIFF
--- a/app/controllers/pseudo_kiosk/authentication_controller.rb
+++ b/app/controllers/pseudo_kiosk/authentication_controller.rb
@@ -1,5 +1,4 @@
 class PseudoKiosk::AuthenticationController < ApplicationController
-  skip_before_action :verify_authenticity_token
   def unlock
     unless session[:pseudo_kiosk_enabled]
       redirect_back(fallback_location: root_path) 

--- a/app/views/pseudo_kiosk/authentication/unlock.html.erb
+++ b/app/views/pseudo_kiosk/authentication/unlock.html.erb
@@ -184,7 +184,8 @@ input[type=submit] {
     <input type="range" value="0" class="pullee" />
 </div>
 <% # This is bad... I am having a problem using the named routes within the rails engine plugin %>
-<%= form_tag 'process_submit', authenticity_token: true do %>
+<%= form_tag 'process_submit', authenticity_token: false do %>
+<%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
 <div id="pass_window" class="center-xy">
     <h1>Passcode:</h1>
     <div id="invalid">Invalid Passcode! Please try again.</div>


### PR DESCRIPTION
Something very odd is going on such that the automatically generated CSRF token on the `process_submit` form is invalid. We can work around this by disabling it in the form options and manually adding the hidden field which submits a valid CSRF token.